### PR TITLE
Use latest @actions/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "yaml-schema-checker",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "yaml-schema-checker",
-            "version": "0.0.7",
+            "version": "0.0.8",
             "license": "MIT",
             "dependencies": {
-                "@actions/core": "1.8.2",
+                "@actions/core": "1.10",
                 "glob": "8.0.3",
                 "js-yaml": "4.1.0",
                 "jsonschema": "1.4.1"
@@ -27,11 +27,12 @@
             }
         },
         "node_modules/@actions/core": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.2.tgz",
-            "integrity": "sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
             "dependencies": {
-                "@actions/http-client": "^2.0.1"
+                "@actions/http-client": "^2.0.1",
+                "uuid": "^8.3.2"
             }
         },
         "node_modules/@actions/http-client": {
@@ -5655,6 +5656,14 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/v8-compile-cache": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -5788,11 +5797,12 @@
     },
     "dependencies": {
         "@actions/core": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.2.tgz",
-            "integrity": "sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
             "requires": {
-                "@actions/http-client": "^2.0.1"
+                "@actions/http-client": "^2.0.1",
+                "uuid": "^8.3.2"
             }
         },
         "@actions/http-client": {
@@ -9974,6 +9984,11 @@
             "requires": {
                 "punycode": "^2.1.0"
             }
+        },
+        "uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "node": ">=16.14.0"
     },
     "dependencies": {
-        "@actions/core": "1.8.2",
+        "@actions/core": "1.10.0",
         "glob": "8.0.3",
         "js-yaml": "4.1.0",
         "jsonschema": "1.4.1"


### PR DESCRIPTION
 The `::set-output` being used by the older version of `actions/core` will soon no longer work.

<img width="1399" alt="Screen Shot 2023-03-09 at 2 25 47 PM" src="https://user-images.githubusercontent.com/897368/224133014-5906b4cd-8fb3-4b9f-a91c-946426bcc8b8.png">

`1.10.0` uses the correct commands,
https://github.com/actions/toolkit/blob/main/packages/core/RELEASES.md#1100